### PR TITLE
feat: add check_allowed method to trait Tracing

### DIFF
--- a/pingora-core/src/connectors/l4.rs
+++ b/pingora-core/src/connectors/l4.rs
@@ -23,7 +23,7 @@ use crate::protocols::{GetSocketDigest, SocketDigest};
 use crate::upstreams::peer::Peer;
 use async_trait::async_trait;
 use log::debug;
-use pingora_error::{Context, Error, ErrorType::*, OrErr, Result,};
+use pingora_error::{Context, Error, ErrorType::*, OrErr, Result};
 use rand::seq::SliceRandom;
 use std::net::SocketAddr as InetSocketAddr;
 #[cfg(unix)]

--- a/pingora-core/src/upstreams/peer.rs
+++ b/pingora-core/src/upstreams/peer.rs
@@ -44,6 +44,10 @@ pub use crate::protocols::tls::ALPN;
 
 /// The interface to trace the connection
 pub trait Tracing: Send + Sync + std::fmt::Debug {
+    /// Checks if the connection is allowed
+    fn check_allowed(&self) -> Result<()> {
+        Ok(())
+    }
     /// This method is called when successfully connected to a remote server
     fn on_connected(&self);
     /// This method is called when the connection is disconnected.


### PR DESCRIPTION
Patches the `Tracing` interface to add a `check_allowed` method. This changes the interface semantics, but allows to delegate the permission to create a new connection to the implementation of the trait.